### PR TITLE
Fix markdown rendering: backtick encoding and list spacing

### DIFF
--- a/frontend/src/components/resources/mod-detail/DownloadDialogs.tsx
+++ b/frontend/src/components/resources/mod-detail/DownloadDialogs.tsx
@@ -420,7 +420,13 @@ export const HistoryModal: React.FC<any> = ({ show, onClose, history, showExperi
                                     {ver.changelog ? (
                                         <div className="mt-2">
                                             <div className={`prose prose-sm dark:prose-invert max-w-none text-slate-400 ${expandedChangelog === ver.id ? '' : 'line-clamp-3'}`}>
-                                                <ReactMarkdown rehypePlugins={[rehypeRaw, rehypeSanitize]}>{ver.changelog}</ReactMarkdown>
+                                                <ReactMarkdown
+                                                    rehypePlugins={[rehypeRaw, rehypeSanitize]}
+                                                    components={{
+                                                        li: ({children, ...props}: any) => <li className="my-0.5 [&>p]:my-0" {...props}>{children}</li>,
+                                                        p: ({children, ...props}: any) => <p className="my-1" {...props}>{children}</p>
+                                                    }}
+                                                >{ver.changelog}</ReactMarkdown>
                                             </div>
                                             {isLong && (
                                                 <button onClick={() => setExpandedChangelog(expandedChangelog === ver.id ? null : ver.id)} className="mt-3 text-xs font-bold text-modtale-accent hover:underline flex items-center gap-1">

--- a/frontend/src/components/resources/upload/ProjectBuilder.tsx
+++ b/frontend/src/components/resources/upload/ProjectBuilder.tsx
@@ -235,10 +235,22 @@ export const ProjectBuilder: React.FC<ProjectBuilderProps> = ({
                     {String(children).replace(/\n$/, '')}
                 </SyntaxHighlighter>
             ) : (
-                <code className={`${className} bg-slate-100 dark:bg-white/10 px-1 py-0.5 rounded text-sm`} {...props}>
+                <code className={`${className || ''} bg-slate-100 dark:bg-white/10 px-1 py-0.5 rounded text-sm`} {...props}>
                     {children}
                 </code>
             )
+        },
+        p({node, children, ...props}: any) {
+            return <p className="my-2 [li>&]:my-0" {...props}>{children}</p>
+        },
+        li({node, children, ...props}: any) {
+            return <li className="my-1 [&>p]:my-0" {...props}>{children}</li>
+        },
+        ul({node, children, ...props}: any) {
+            return <ul className="list-disc pl-6 my-3" {...props}>{children}</ul>
+        },
+        ol({node, children, ...props}: any) {
+            return <ol className="list-decimal pl-6 my-3" {...props}>{children}</ol>
         }
     };
 

--- a/frontend/src/context/SSRContext.tsx
+++ b/frontend/src/context/SSRContext.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
+
+declare global {
+    interface Window {
+        INITIAL_DATA?: any;
+    }
+}
 
 interface SSRContextType {
     initialData: any | null;
@@ -7,8 +13,15 @@ interface SSRContextType {
 const SSRContext = createContext<SSRContextType>({ initialData: null });
 
 export const SSRProvider: React.FC<{ data: any, children: React.ReactNode }> = ({ data, children }) => {
+    const initialData = useMemo(() => {
+        if (typeof window !== 'undefined' && window.INITIAL_DATA) {
+            return window.INITIAL_DATA;
+        }
+        return data;
+    }, [data]);
+
     return (
-        <SSRContext.Provider value={{ initialData: data }}>
+        <SSRContext.Provider value={{ initialData }}>
             {children}
         </SSRContext.Provider>
     );

--- a/frontend/src/layouts/BaseLayout.astro
+++ b/frontend/src/layouts/BaseLayout.astro
@@ -60,9 +60,7 @@ const jsonLdString = jsonLd ? JSON.stringify(jsonLd) : null;
 
     {jsonLdString && <script type="application/ld+json" set:html={jsonLdString} />}
 
-    <script define:vars={{ initialData }}>
-        window.INITIAL_DATA = initialData;
-    </script>
+    <script is:inline set:html={`window.INITIAL_DATA = ${initialDataString};`}></script>
 
     <script is:inline>
         (function() {

--- a/frontend/src/react-pages/resources/ModDetail.tsx
+++ b/frontend/src/react-pages/resources/ModDetail.tsx
@@ -852,10 +852,22 @@ export const ModDetail: React.FC<{
                                                     {String(children).replace(/\n$/, '')}
                                                 </SyntaxHighlighter>
                                             ) : (
-                                                <code className={`${className} bg-slate-100 dark:bg-white/10 px-1 py-0.5 rounded text-sm`} {...props}>
+                                                <code className={`${className || ''} bg-slate-100 dark:bg-white/10 px-1 py-0.5 rounded text-sm`} {...props}>
                                                     {children}
                                                 </code>
                                             )
+                                        },
+                                        p({node, children, ...props}: any) {
+                                            return <p className="my-2 [li>&]:my-0" {...props}>{children}</p>
+                                        },
+                                        li({node, children, ...props}: any) {
+                                            return <li className="my-1 [&>p]:my-0" {...props}>{children}</li>
+                                        },
+                                        ul({node, children, ...props}: any) {
+                                            return <ul className="list-disc pl-6 my-3" {...props}>{children}</ul>
+                                        },
+                                        ol({node, children, ...props}: any) {
+                                            return <ol className="list-decimal pl-6 my-3" {...props}>{children}</ol>
                                         }
                                     }}
                                 >


### PR DESCRIPTION
## What's broken
- Backticks showing as `&#96;` instead of rendering code blocks/inline code
- Lists with inline code have way too much vertical spacing

## Why it's happening
Astro's `define:vars` HTML-encodes special characters when passing SSR data to scripts. So backticks get converted to `&#96;` entities before react-markdown ever sees them.

The list spacing issue is just Tailwind's prose styles adding margins to `<p>` tags that get inserted inside `<li>` elements.

## The fix
- Switched to `JSON.stringify` + `set:html` in BaseLayout.astro to avoid the encoding
- Made SSRContext read from `window.INITIAL_DATA` on the client side
- Added `[&>p]:my-0` to list items to kill the extra paragraph margins